### PR TITLE
edit set up  to add permission

### DIFF
--- a/AZD-SETUP.md
+++ b/AZD-SETUP.md
@@ -25,19 +25,15 @@ azd version
 ```bash
 git clone https://github.com/microsoft/AIforITOps.git
 cd AIforITOps
-```
-
-4. **macOS/Linux only: make azd hook scripts executable**:
-
-```bash
+# macOS/Linux only: make azd hook scripts executable
 chmod +x infra/hooks/*.sh
 ```
 
-5. **Install required tools** (if not already installed):
+4. **Install required tools** (if not already installed):
    - Azure CLI: `winget install Microsoft.AzureCLI`
    - kubectl: `az aks install-cli`
 
-6. **Login to Azure**:
+5. **Login to Azure**:
 
 ```bash
 # Login to Azure with azd

--- a/AZD-SETUP.md
+++ b/AZD-SETUP.md
@@ -27,11 +27,17 @@ git clone https://github.com/microsoft/AIforITOps.git
 cd AIforITOps
 ```
 
-4. **Install required tools** (if not already installed):
+4. **macOS/Linux only: make azd hook scripts executable**:
+
+```bash
+chmod +x infra/hooks/*.sh
+```
+
+5. **Install required tools** (if not already installed):
    - Azure CLI: `winget install Microsoft.AzureCLI`
    - kubectl: `az aks install-cli`
 
-5. **Login to Azure**:
+6. **Login to Azure**:
 
 ```bash
 # Login to Azure with azd


### PR DESCRIPTION
When I was trying out azd on my Mac I noticed it require permission on the script to run it. 

got this error 

ERROR: step "cmdhook-postprovision" failed: 'postprovision' hook failed with exit code: '126', Path: '/Users/nicholas/Desktop/AIforITOps/infra/hooks/postprovision.sh'. : exit code: 126, stdout: , stderr: /bin/sh: /Users/nicholas/Desktop/AIforITOps/infra/hooks/postprovision.sh: Permission denied

Had to edit the permission on hooks.sh before it work. 